### PR TITLE
Battlecry ability

### DIFF
--- a/Game/config.xml
+++ b/Game/config.xml
@@ -16,9 +16,9 @@
 	</gui>
 	<window>
 		<resolution width="1680" height="1050" scale="1" />
-		<fullscreen value="true" />
+		<fullscreen value="false" />
 		<borderless value="false" />
-		<resizable value="true" />
+		<resizable value="false" />
 		<fullscreen_window value="false" />
 		<set_title />
 	</window>

--- a/Game/config.xml
+++ b/Game/config.xml
@@ -15,10 +15,10 @@
 		<atlas file="gui/ui.png" />
 	</gui>
 	<window>
-		<resolution width="1500" height="800" scale="1" />
-		<fullscreen value="false" />
+		<resolution width="1680" height="1050" scale="1" />
+		<fullscreen value="true" />
 		<borderless value="false" />
-		<resizable value="false" />
+		<resizable value="true" />
 		<fullscreen_window value="false" />
 		<set_title />
 	</window>

--- a/Game/config.xml
+++ b/Game/config.xml
@@ -15,7 +15,7 @@
 		<atlas file="gui/ui.png" />
 	</gui>
 	<window>
-		<resolution width="1680" height="1050" scale="1" />
+		<resolution width="1500" height="800" scale="1" />
 		<fullscreen value="false" />
 		<borderless value="false" />
 		<resizable value="false" />

--- a/Motor2D/Building.h
+++ b/Motor2D/Building.h
@@ -40,8 +40,6 @@ public:
 
 public:
 
-	int cost = 0;
-
 	iPoint position = NULLPOINT;
 	iPoint offset = NULLPOINT;
 

--- a/Motor2D/Entity.h
+++ b/Motor2D/Entity.h
@@ -61,6 +61,10 @@ public:
 public:
 	entity_type type = entity_type::null;
 	bool to_delete = false;
+
+	int life = 0;
+	int cost = 0; // only for allies
+
 protected:
 	bool selected = false;
 };

--- a/Motor2D/Player.cpp
+++ b/Motor2D/Player.cpp
@@ -16,6 +16,7 @@
 #include "Swordsman.h"
 #include "SceneTest.h"
 #include "j1Scene.h"
+#include "j1Window.h"
 
 Player::Player()
 {
@@ -51,7 +52,7 @@ bool Player::Start()
 	level_points_txt = (UI_Text*)levelup_window->CreateText({ 150, 1017 }, App->font->default_10);
 	levelup_window->SetEnabledAndChilds(false);
 
-	barracks_ui_window = (UI_Window*)App->gui->UI_CreateWin(iPoint(280, 200), 225, 144, 99);
+	barracks_ui_window = (UI_Window*)App->gui->UI_CreateWin(iPoint(280, 200), 225, 144, 98);
 
 	create_unit_button = (UI_Button*)barracks_ui_window->CreateButton(iPoint(285, 500), 60, 60);
 	create_unit_button->AddImage("standard", { 705, 0, 60, 60 });
@@ -74,6 +75,17 @@ bool Player::Start()
 	swordsman_img->click_through = true;
 
 	barracks_ui_window->SetEnabledAndChilds(false);
+
+	//player abilities
+
+	player_abilities = (UI_Window*)App->gui->UI_CreateWin(iPoint(400, 200), 200, 60, 99);
+
+	shout_ability = (UI_Button*)player_abilities->CreateButton(iPoint(App->win->_GetWindowSize().x / 7, App->win->_GetWindowSize().y - App->win->_GetWindowSize().y / 10), 60, 60);
+	shout_ability->AddImage("standard", { 705, 0, 60, 60 });
+	shout_ability->SetImage("standard");
+	shout_ability->AddImage("clicked", { 645, 0, 60, 60 });
+
+	//player_abilities->SetEnabledAndChilds(false);
 
 	return ret;
 }
@@ -130,6 +142,24 @@ bool Player::PreUpdate()
 		create_unit_button2->SetImage("standard");
 	}
 
+	//player abilities
+
+	if (shout_ability->MouseClickEnterLeft() && shout_ability->CompareState("standard")) {
+		shout_ability->SetImage("clicked");
+	
+		shout_state = true;
+		// buffed variable of allys set to true and give + 5 dmg to them
+		shout_timer.Start();
+	}
+	
+	if (shout_timer.ReadSec() >= 10) {
+		shout_ability->SetImage("standard");
+	}
+	
+	else if (shout_timer.ReadSec() >= 5) {
+		shout_state = false;
+		// - 5 dmg to buffed allys and set buffed variable to false
+	}
 
 	return ret;
 }

--- a/Motor2D/Player.cpp
+++ b/Motor2D/Player.cpp
@@ -143,15 +143,15 @@ bool Player::PreUpdate()
 	}
 
 	//player abilities
-	if (battlecry_ability->MouseEnter()) {
+	if (battlecry_ability->MouseEnter() || App->input->GetKey(SDL_SCANCODE_X) == key_repeat) {
 		draw = true;
 	}
 
-	if (battlecry_ability->MouseOut()) {
+	else if (battlecry_ability->MouseOut() || App->input->GetKey(SDL_SCANCODE_X) == key_up) {
 		draw = false;
 	}
 
-	if (battlecry_ability->MouseClickEnterLeft() && battlecry_ability->CompareState("standard")) {
+	if ((battlecry_ability->MouseClickEnterLeft() && battlecry_ability->CompareState("standard")) || App->input->GetKey(SDL_SCANCODE_X) == key_repeat && App->input->GetMouseButtonDown(SDL_BUTTON_LEFT) == key_down) {
 		battlecry_ability->SetImage("clicked");
 	
 		battlecry_state = true;

--- a/Motor2D/Player.cpp
+++ b/Motor2D/Player.cpp
@@ -81,9 +81,9 @@ bool Player::Start()
 	player_abilities = (UI_Window*)App->gui->UI_CreateWin(iPoint(400, 200), 200, 60, 12);
 
 	battlecry_ability = (UI_Button*)player_abilities->CreateButton(iPoint(App->win->_GetWindowSize().x / 7, App->win->_GetWindowSize().y - App->win->_GetWindowSize().y / 10), 60, 60);
-	battlecry_ability->AddImage("standard", { 705, 0, 60, 60 });
+	battlecry_ability->AddImage("standard", { 517, 0, 64, 64 });
 	battlecry_ability->SetImage("standard");
-	battlecry_ability->AddImage("clicked", { 645, 0, 60, 60 });
+	battlecry_ability->AddImage("clicked", { 581, 0, 64, 64 });
 
 	//player_abilities->SetEnabledAndChilds(false);
 
@@ -178,7 +178,7 @@ bool Player::Update(float dt)
 {
 	bool ret = true;
 
-	if (App->input->GetMouseButtonDown(SDL_BUTTON_LEFT) == key_down && App->gui->GetMouseHover() == nullptr) {
+	if (App->input->GetMouseButtonDown(SDL_BUTTON_LEFT) == key_down && App->gui->GetMouseHover() == nullptr && App->input->GetKey(SDL_SCANCODE_X) != key_repeat) {
 		iPoint mouse;
 		App->input->GetMouseWorld(mouse.x, mouse.y);
 		App->entity->UnselectEverything();
@@ -263,7 +263,7 @@ bool Player::PostUpdate()
 	}
 	
 	if (draw == true) {
-		App->render->DrawCircle(hero->position.x + App->render->camera.x, hero->position.y + App->render->camera.y, METERS_TO_PIXELS(8), 255, 255, 255, 255); // radius needs revision
+		App->render->DrawCircle(hero->position.x + App->render->camera.x, hero->position.y + App->render->camera.y, METERS_TO_PIXELS(8), 255, 0, 0, 255); // radius needs revision
 	}
 
 	return ret;

--- a/Motor2D/Player.cpp
+++ b/Motor2D/Player.cpp
@@ -80,10 +80,10 @@ bool Player::Start()
 
 	player_abilities = (UI_Window*)App->gui->UI_CreateWin(iPoint(400, 200), 200, 60, 12);
 
-	shout_ability = (UI_Button*)player_abilities->CreateButton(iPoint(App->win->_GetWindowSize().x / 7, App->win->_GetWindowSize().y - App->win->_GetWindowSize().y / 10), 60, 60);
-	shout_ability->AddImage("standard", { 705, 0, 60, 60 });
-	shout_ability->SetImage("standard");
-	shout_ability->AddImage("clicked", { 645, 0, 60, 60 });
+	battlecry_ability = (UI_Button*)player_abilities->CreateButton(iPoint(App->win->_GetWindowSize().x / 7, App->win->_GetWindowSize().y - App->win->_GetWindowSize().y / 10), 60, 60);
+	battlecry_ability->AddImage("standard", { 705, 0, 60, 60 });
+	battlecry_ability->SetImage("standard");
+	battlecry_ability->AddImage("clicked", { 645, 0, 60, 60 });
 
 	//player_abilities->SetEnabledAndChilds(false);
 
@@ -143,30 +143,30 @@ bool Player::PreUpdate()
 	}
 
 	//player abilities
-	if (shout_ability->MouseEnter()) {
+	if (battlecry_ability->MouseEnter()) {
 		draw = true;
 	}
 
-	if (shout_ability->MouseOut()) {
+	if (battlecry_ability->MouseOut()) {
 		draw = false;
 	}
 
-	if (shout_ability->MouseClickEnterLeft() && shout_ability->CompareState("standard")) {
-		shout_ability->SetImage("clicked");
+	if (battlecry_ability->MouseClickEnterLeft() && battlecry_ability->CompareState("standard")) {
+		battlecry_ability->SetImage("clicked");
 	
-		shout_state = true;
+		battlecry_state = true;
 		Battlecry();
 		BattlecryModifier(5);
 
-		shout_timer.Start();
+		battlecry_timer.Start();
 	}
 	
-	if (shout_timer.ReadSec() >= 10) {
-		shout_ability->SetImage("standard");
+	if (battlecry_timer.ReadSec() >= 10) {
+		battlecry_ability->SetImage("standard");
 	}
 	
-	else if (shout_timer.ReadSec() >= 5) {
-		shout_state = false;
+	else if (battlecry_timer.ReadSec() >= 5) {
+		battlecry_state = false;
 		BattlecryModifier(-5);
 		buffed_list.clear();
 	}

--- a/Motor2D/Player.cpp
+++ b/Motor2D/Player.cpp
@@ -258,7 +258,7 @@ bool Player::PostUpdate()
 	}
 	
 	if (draw_battlecry_range == true)
-		App->render->DrawCircle(hero->position.x + App->render->camera.x, hero->position.y + App->render->camera.y, METERS_TO_PIXELS(8), 255, 0, 0, 255); // radius needs revision
+		App->render->DrawCircle(hero->position.x + App->render->camera.x, hero->position.y + App->render->camera.y, METERS_TO_PIXELS(5), 255, 0, 0, 255); // radius needs revision
 
 	if (draw_buff == true)
 		DrawBuff();
@@ -407,11 +407,11 @@ void Player::BattlecryModifier(int damage_buff)
 
 void Player::DrawBuff()
 {
-	if (buffed_list.empty() != true) {
-		for (std::list<Unit*>::iterator it = buffed_list.begin(); it != buffed_list.end(); it++) {
-			App->scene->LayerBlit(5, (*it)->GetGameObject()->GetTexture(), { (*it)->position.x + 10, (*it)->position.y + 10 }, (*it)->current_animation->GetAnimationFrame(1) );
-		}
-	}
+	//if (buffed_list.empty() != true) {
+	//	for (std::list<Unit*>::iterator it = buffed_list.begin(); it != buffed_list.end(); it++) {
+	//		App->scene->LayerBlit(5, (*it)->GetGameObject()->GetTexture(), { (*it)->position.x + 10, (*it)->position.y + 10 }, (*it)->current_animation->GetAnimationFrame(1) );
+	//	}
+	//}
 }
 
 void Player::StopBuff(int modifier)

--- a/Motor2D/Player.cpp
+++ b/Motor2D/Player.cpp
@@ -157,6 +157,7 @@ bool Player::PreUpdate()
 		battlecry_state = true;
 		Battlecry();
 		BattlecryModifier(5);
+		draw_buff = true;
 
 		battlecry_timer.Start();
 	}
@@ -166,6 +167,7 @@ bool Player::PreUpdate()
 	}
 	
 	else if (battlecry_timer.ReadSec() >= 5) {
+		draw_buff = false;
 		battlecry_state = false;
 		BattlecryModifier(-5);
 		buffed_list.clear();
@@ -262,9 +264,11 @@ bool Player::PostUpdate()
 		UpdateAttributes();
 	}
 	
-	if (draw == true) {
+	if (draw == true)
 		App->render->DrawCircle(hero->position.x + App->render->camera.x, hero->position.y + App->render->camera.y, METERS_TO_PIXELS(8), 255, 0, 0, 255); // radius needs revision
-	}
+
+	if (draw_buff == true)
+		DrawBuff();
 
 	return ret;
 }
@@ -383,5 +387,15 @@ void Player::BattlecryModifier(int damage_buff)
 {
 	for (std::list<Unit*>::iterator it = buffed_list.begin(); it != buffed_list.end(); it++) {
 		(*it)->damage += damage_buff;
+	}
+}
+
+void Player::DrawBuff()
+{
+	if (buffed_list.empty() != true) {
+		for (std::list<Unit*>::iterator it = buffed_list.begin(); it != buffed_list.end(); it++) {
+			App->scene->LayerBlit(5, (*it)->GetGameObject()->GetTexture(), { (*it)->position.x + 10, (*it)->position.y + 10 }, (*it)->current_animation->GetAnimationFrame(1) );
+			hero->life += 1;
+		}
 	}
 }

--- a/Motor2D/Player.cpp
+++ b/Motor2D/Player.cpp
@@ -80,12 +80,13 @@ bool Player::Start()
 
 	player_abilities = (UI_Window*)App->gui->UI_CreateWin(iPoint(400, 200), 200, 60, 12);
 
-	battlecry_ability = (UI_Button*)player_abilities->CreateButton(iPoint(App->win->_GetWindowSize().x / 7, App->win->_GetWindowSize().y - App->win->_GetWindowSize().y / 10), 60, 60);
-	battlecry_ability->AddImage("standard", { 517, 0, 64, 64 });
+	battlecry_ability = (UI_Button*)player_abilities->CreateButton(iPoint(App->win->_GetWindowSize().x / 17 + App->win->_GetWindowSize().x / 400, App->win->_GetWindowSize().y - App->win->_GetWindowSize().y / 9), 60, 60);
+	battlecry_ability->AddImage("standard", { 645, 60, 25, 25 });
 	battlecry_ability->SetImage("standard");
-	battlecry_ability->AddImage("clicked", { 581, 0, 64, 64 });
+	battlecry_ability->AddImage("clicked", { 670, 60, 25, 25 });
 
-	//player_abilities->SetEnabledAndChilds(false);
+	battlecry_cd = (UI_Text*)player_abilities->CreateText({ App->win->_GetWindowSize().x / 16, App->win->_GetWindowSize().y - App->win->_GetWindowSize().y / 9 }, App->font->default_15);
+	battlecry_cd->SetEnabled(false);
 
 	return ret;
 }
@@ -158,15 +159,17 @@ bool Player::PreUpdate()
 		Battlecry();
 		BattlecryModifier(5);
 		draw_buff = true;
+		battlecry_cd->SetEnabled(true);
 
 		battlecry_timer.Start();
 	}
 	
-	if (battlecry_timer.ReadSec() >= 10) {
+	if (battlecry_timer.ReadSec() >= COOLDOWN_BATTLECRY) {
+		battlecry_cd->SetEnabled(false);
 		battlecry_ability->SetImage("standard");
 	}
 	
-	else if (battlecry_timer.ReadSec() >= 5) {
+	else if (battlecry_timer.ReadSec() >= DURATION_BATTLECRY) {
 		draw_buff = false;
 		battlecry_state = false;
 		BattlecryModifier(-5);
@@ -269,6 +272,10 @@ bool Player::PostUpdate()
 
 	if (draw_buff == true)
 		DrawBuff();
+
+	if (battlecry_timer.ReadSec() <= COOLDOWN_BATTLECRY) {
+		DrawCD(1);
+	}
 
 	return ret;
 }
@@ -385,7 +392,8 @@ void Player::Battlecry() {
 
 void Player::BattlecryModifier(int damage_buff)
 {
-	for (std::list<Unit*>::iterator it = buffed_list.begin(); it != buffed_list.end(); it++) {
+	for (std::list<Unit*>::iterator it = buffed_list.begin(); it != buffed_list.end(); it++) 
+	{
 		(*it)->damage += damage_buff;
 	}
 }
@@ -397,5 +405,25 @@ void Player::DrawBuff()
 			App->scene->LayerBlit(5, (*it)->GetGameObject()->GetTexture(), { (*it)->position.x + 10, (*it)->position.y + 10 }, (*it)->current_animation->GetAnimationFrame(1) );
 			hero->life += 1;
 		}
+	}
+}
+
+void Player::DrawCD(int ability_number)
+{
+	std::stringstream oss;
+
+	if (ability_number == 1) {
+		int timer = COOLDOWN_BATTLECRY - battlecry_timer.ReadSec() + 1;
+		oss << timer;
+		std::string txt = oss.str();
+		battlecry_cd->SetText(txt);
+	}
+
+	else if (ability_number == 2) {
+
+	}
+
+	else if (ability_number == 3) {
+
 	}
 }

--- a/Motor2D/Player.cpp
+++ b/Motor2D/Player.cpp
@@ -145,11 +145,11 @@ bool Player::PreUpdate()
 
 	//player abilities
 	if (battlecry_ability->MouseEnter() || App->input->GetKey(SDL_SCANCODE_X) == key_repeat) {
-		draw = true;
+		draw_battlecry_range = true;
 	}
 
 	else if (battlecry_ability->MouseOut() || App->input->GetKey(SDL_SCANCODE_X) == key_up) {
-		draw = false;
+		draw_battlecry_range = false;
 	}
 
 	if ((battlecry_ability->MouseClickEnterLeft() && battlecry_ability->CompareState("standard")) || App->input->GetKey(SDL_SCANCODE_X) == key_repeat && App->input->GetMouseButtonDown(SDL_BUTTON_LEFT) == key_down) {
@@ -267,14 +267,14 @@ bool Player::PostUpdate()
 		UpdateAttributes();
 	}
 	
-	if (draw == true)
+	if (draw_battlecry_range == true)
 		App->render->DrawCircle(hero->position.x + App->render->camera.x, hero->position.y + App->render->camera.y, METERS_TO_PIXELS(8), 255, 0, 0, 255); // radius needs revision
 
 	if (draw_buff == true)
 		DrawBuff();
 
 	if (battlecry_timer.ReadSec() <= COOLDOWN_BATTLECRY) {
-		DrawCD(1);
+		DrawCD(1); // 1 == Battlecry
 	}
 
 	return ret;

--- a/Motor2D/Player.h
+++ b/Motor2D/Player.h
@@ -7,6 +7,9 @@
 
 #include "Point.h"
 
+#define DURATION_BATTLECRY 5
+#define COOLDOWN_BATTLECRY 10
+
 class Unit;
 class UI_Window;
 class UI_Text;
@@ -28,12 +31,16 @@ public:
 	void BattlecryModifier(int damage_buff);
 	void DrawBuff();
 
+	void DrawCD(int ability_number);
+
 private:
 	UI_Window* attributes_window = nullptr;
 	UI_Text* life_txt = nullptr;
 	UI_Text* damage_txt = nullptr;
 	UI_Text* armor_txt = nullptr;
 	UI_Text* pierce_armor_txt = nullptr;
+
+	UI_Text* battlecry_cd = nullptr;
 
 	UI_Window* levelup_window = nullptr;
 	UI_Button* life_button = nullptr;

--- a/Motor2D/Player.h
+++ b/Motor2D/Player.h
@@ -64,18 +64,18 @@ private:
 	UI_Button* create_unit_button2 = nullptr;
 
 	//buttons for abilities
-	UI_Button* shout_ability = nullptr;
+	UI_Button* battlecry_ability = nullptr;
 
 public:
 	bool create_barbarian = true;
 	bool create_swordsman = false;
 
 	//player abilities
-	bool shout_state = false;
+	bool battlecry_state = false;
 	bool draw = false;
 
 private:
-	j1Timer shout_timer;
+	j1Timer battlecry_timer;
 };
 
 

--- a/Motor2D/Player.h
+++ b/Motor2D/Player.h
@@ -24,6 +24,9 @@ public:
 	bool PostUpdate();
 	bool CleanUp();
 
+	void Battlecry();
+	void BattlecryModifier(int damage_buff);
+
 private:
 	UI_Window* attributes_window = nullptr;
 	UI_Text* life_txt = nullptr;
@@ -46,6 +49,9 @@ private:
 public:
 	void SetHero(Hero* hero);
 	Hero* GetHero();
+
+	std::list<Unit*> buffed_list;
+
 public:
 	UI_Window* barracks_ui_window = nullptr;
 	UI_Window* player_abilities = false;
@@ -66,6 +72,7 @@ public:
 
 	//player abilities
 	bool shout_state = false;
+	bool draw = false;
 
 private:
 	j1Timer shout_timer;

--- a/Motor2D/Player.h
+++ b/Motor2D/Player.h
@@ -26,6 +26,7 @@ public:
 
 	void Battlecry();
 	void BattlecryModifier(int damage_buff);
+	void DrawBuff();
 
 private:
 	UI_Window* attributes_window = nullptr;
@@ -73,6 +74,7 @@ public:
 	//player abilities
 	bool battlecry_state = false;
 	bool draw = false;
+	bool draw_buff = false;
 
 private:
 	j1Timer battlecry_timer;

--- a/Motor2D/Player.h
+++ b/Motor2D/Player.h
@@ -3,6 +3,7 @@
 
 #include "j1Module.h"
 #include "SDL/include/SDL.h"
+#include "j1Timer.h"
 
 #include "Point.h"
 
@@ -47,6 +48,7 @@ public:
 	Hero* GetHero();
 public:
 	UI_Window* barracks_ui_window = nullptr;
+	UI_Window* player_abilities = false;
 	iPoint barracks_position;
 
 private:
@@ -55,10 +57,18 @@ private:
 	UI_Button* create_unit_button = nullptr;
 	UI_Button* create_unit_button2 = nullptr;
 
+	//buttons for abilities
+	UI_Button* shout_ability = nullptr;
+
 public:
 	bool create_barbarian = true;
 	bool create_swordsman = false;
 
+	//player abilities
+	bool shout_state = false;
+
+private:
+	j1Timer shout_timer;
 };
 
 

--- a/Motor2D/Player.h
+++ b/Motor2D/Player.h
@@ -10,6 +10,7 @@
 #define DURATION_BATTLECRY 5
 #define COOLDOWN_BATTLECRY 10
 #define BATTLECRY_BUFF 5
+#define BATTLECRY_RANGE 10
 
 class Unit;
 class UI_Window;
@@ -28,8 +29,9 @@ public:
 	bool PostUpdate();
 	bool CleanUp();
 
-	void Battlecry(int modifier);
+	void Battlecry(int modifier, int range);
 	void BattlecryModifier(int damage_buff);
+	void CheckBattlecryRange(int range);
 	void DrawBuff();
 	void StopBuff(int modifier);
 	void DrawCD(int ability_number);
@@ -59,10 +61,7 @@ public:
 	void SetHero(Hero* hero);
 	Hero* GetHero();
 
-
-
 	std::list<Unit*> buffed_list;
-
 public:
 	UI_Window* barracks_ui_window = nullptr;
 	UI_Window* player_abilities = false;

--- a/Motor2D/Player.h
+++ b/Motor2D/Player.h
@@ -80,7 +80,7 @@ public:
 
 	//player abilities
 	bool battlecry_state = false;
-	bool draw = false;
+	bool draw_battlecry_range = false;
 	bool draw_buff = false;
 
 private:

--- a/Motor2D/Player.h
+++ b/Motor2D/Player.h
@@ -9,6 +9,7 @@
 
 #define DURATION_BATTLECRY 5
 #define COOLDOWN_BATTLECRY 10
+#define BATTLECRY_BUFF 5
 
 class Unit;
 class UI_Window;
@@ -27,10 +28,10 @@ public:
 	bool PostUpdate();
 	bool CleanUp();
 
-	void Battlecry();
+	void Battlecry(int modifier);
 	void BattlecryModifier(int damage_buff);
 	void DrawBuff();
-
+	void StopBuff(int modifier);
 	void DrawCD(int ability_number);
 
 private:
@@ -57,6 +58,8 @@ private:
 public:
 	void SetHero(Hero* hero);
 	Hero* GetHero();
+
+
 
 	std::list<Unit*> buffed_list;
 

--- a/Motor2D/SceneTest.cpp
+++ b/Motor2D/SceneTest.cpp
@@ -160,7 +160,7 @@ void SceneTest::CheckUnitCreation(iPoint p)
 		gold -= sword->cost;
 		current_human_resources += sword->human_cost;
 	}
-	else if (App->input->GetKey(SDL_SCANCODE_B) == key_down && gold >= 100 && create_barrack == true)
+	else if (App->input->GetKey(SDL_SCANCODE_B) == key_down && gold >= 90 && create_barrack == true)
 	{
 		Barracks* barrack = (Barracks*)App->entity->CreateEntity(barracks, building);
 		barrack->game_object->SetPos(fPoint(App->map->MapToWorld(p.x + TROOP_OFFSET, p.y).x, App->map->MapToWorld(p.x + TROOP_OFFSET, p.y).y));

--- a/Motor2D/Unit.h
+++ b/Motor2D/Unit.h
@@ -168,12 +168,13 @@ public:
 	uint radius_of_action = 0;
 
 private:
-		j1Timer death_timer;
-		j1Timer AI_timer;
+	j1Timer death_timer;
+	j1Timer AI_timer;
 public:
 	bool IsInsideCircle(int x, int y);
 
 public:
+	// attacked audio
 	bool shout_fx = true;
 };
 

--- a/Motor2D/Unit.h
+++ b/Motor2D/Unit.h
@@ -105,8 +105,6 @@ public:
 	attack_state att_state = attack_state::attack_null;
 	bool has_moved = false;
 public:
-	int life = 0;
-	int cost = 0; // only for allies
 	int human_cost = 0; // only for allies
 	int gold_drop = 0; // only for enemies
 	float speed = 0;

--- a/Motor2D/Unit.h
+++ b/Motor2D/Unit.h
@@ -166,7 +166,7 @@ public:
 
 public:
 	uint radius_of_action = 0;
-
+	bool buffed = false;
 private:
 	j1Timer death_timer;
 	j1Timer AI_timer;

--- a/Motor2D/j1Gui.cpp
+++ b/Motor2D/j1Gui.cpp
@@ -1156,6 +1156,17 @@ void UI_Button::SetImage(char* name)
 	}
 }
 
+bool UI_Button::CompareState(char* name) {
+	for (list<rect_text>::iterator it = rect_list.begin(); it != rect_list.end(); it++)
+	{
+		if (TextCmp((*it).name.c_str(), name) && curr.x == (*it).rect.x && curr.y == (*it).rect.y && curr.w == (*it).rect.w && curr.h == (*it).rect.h)
+		{
+			return true;
+		}
+	}
+	return false;
+}
+
 // -----------------------------------
 // ---------------------------- Button
 

--- a/Motor2D/j1Gui.h
+++ b/Motor2D/j1Gui.h
@@ -252,6 +252,8 @@ public:
 	void AddImage(char* name, SDL_Rect rect);
 	void SetImage(char* name);
 
+	bool CompareState(char * name);
+
 private:
 	void ChangeButtonStats();
 


### PR DESCRIPTION
Battlecry ability has been added, it still needs a particle for the units affected but will be implemented later on.

To use it the player needs to hold X + left click or press on the ability, and all the allies nearby will get a buff of attack damage for a few seconds.

The range of action is not polished, it will need revision.